### PR TITLE
[add] fileExtensionCheck

### DIFF
--- a/lib/makeTest.js
+++ b/lib/makeTest.js
@@ -44,7 +44,10 @@ export const makeBoolTest = ({ FILENAME, DIRNAME, expectBoolean = true }) => {
     const sinkArr = readdirSync(`${sampleDir}/${source}`, {
       withFileTypes: true,
     })
-      .filter((dirent) => dirent.isFile() && dirent.name.match(/.html$/))
+      .filter(
+        (dirent) =>
+          dirent.isFile() && fileExtensionCheck({ filePath: dirent.name })
+      )
       .map((dirent) => dirent.name);
 
     describe(source, () => {
@@ -64,4 +67,11 @@ export const makeBoolTest = ({ FILENAME, DIRNAME, expectBoolean = true }) => {
       });
     });
   }
+};
+
+// サンプルファイルの拡張子チェック、定義はextsに追加
+const fileExtensionCheck = ({ exts = ['.html'], filePath }) => {
+  return new RegExp(
+    `(?:${exts.map((ext) => ext.replaceAll('.', '\\.')).join('|')})$`
+  ).test(filePath);
 };


### PR DESCRIPTION
ファイル拡張子チェックを別関数にして、許可する拡張子の定義を引数にわたすようにした